### PR TITLE
add per-entry metadata and file-type breakdown to cache UI

### DIFF
--- a/src/components/PwaCacheBucketList.vue
+++ b/src/components/PwaCacheBucketList.vue
@@ -1,11 +1,7 @@
 <template>
   <BaseAccordion type="multiple" v-slot="{ toggle }">
     <ul class="c-pwa-cache__list u-list-reset">
-      <li
-        v-for="bucket in buckets"
-        :key="bucket.name"
-        class="c-pwa-cache__bucket"
-      >
+      <li v-for="bucket in buckets" :key="bucket.name" class="c-pwa-cache__bucket">
         <AccordionItem :value="bucket.name" :disabled="bucket.urls.length === 0">
           <div
             class="c-pwa-cache__bucket-header"
@@ -51,12 +47,32 @@
               · alt: {{ formatRelativeTime(bucket.oldestEntry) }}
             </template>
           </div>
+          <div v-if="bucket.typeBreakdown.length > 0" class="c-pwa-cache__bucket-types">
+            <span
+              v-for="td in bucket.typeBreakdown.slice(0, 6)"
+              :key="td.type"
+              class="c-pwa-cache__type-pill"
+            >
+              {{ td.type.toUpperCase() }} {{ td.count }}
+            </span>
+          </div>
           <AccordionContent>
-            <ul class="c-pwa-cache__urls u-list-reset">
-              <li v-for="url in bucket.urls" :key="url" class="c-pwa-cache__url" :title="url">
-                {{ formatUrl(url) }}
-              </li>
-            </ul>
+            <VList
+              :data="bucket.urls"
+              :style="{ height: `min(${bucket.urls.length * 28}px, 50vh)` }"
+              class="c-pwa-cache__urls"
+            >
+              <template #default="{ item }">
+                <div class="c-pwa-cache__url" :title="item.url">
+                  <span class="c-pwa-cache__url-path">{{ formatUrl(item.url) }}</span>
+                  <span class="c-pwa-cache__url-meta">
+                    <span v-if="item.size !== null" class="c-pwa-cache__url-size">{{ formatBytes(item.size) }}</span>
+                    <span v-if="item.contentType" class="c-pwa-cache__url-type">{{ formatContentType(item.contentType) }}</span>
+                    <span v-if="item.date" class="c-pwa-cache__url-age">{{ formatRelativeTime(item.date) }}</span>
+                  </span>
+                </div>
+              </template>
+            </VList>
           </AccordionContent>
         </AccordionItem>
       </li>
@@ -65,9 +81,16 @@
 </template>
 
 <script setup lang="ts">
-import { AccordionContent, AccordionItem, AccordionTrigger, BaseAccordion } from "@components/accordion";
-import { formatBytes, getBucketDisplayName } from "@composables/useCacheStorage";
 import type { CacheBucket } from "@composables/useCacheStorage";
+
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  BaseAccordion,
+} from "@components/accordion";
+import { formatBytes, getBucketDisplayName } from "@composables/useCacheStorage";
+import { VList } from "virtua/vue";
 import { defineAsyncComponent } from "vue";
 
 defineProps<{
@@ -80,6 +103,26 @@ const emit = defineEmits<{
 
 const ChevronDown = defineAsyncComponent(() => import("virtual:icons/lucide/chevron-down"));
 const X = defineAsyncComponent(() => import("virtual:icons/lucide/x"));
+
+const CONTENT_TYPE_LABELS: Record<string, string> = {
+  "application/javascript": "JS",
+  "application/json": "JSON",
+  "font/woff": "WOFF",
+  "font/woff2": "WOFF2",
+  "image/avif": "AVIF",
+  "image/jpeg": "JPG",
+  "image/png": "PNG",
+  "image/svg+xml": "SVG",
+  "image/webp": "WEBP",
+  "text/css": "CSS",
+  "text/html": "HTML",
+  "text/javascript": "JS",
+};
+
+function formatContentType(contentType: string): string {
+  const type = contentType.split(";")[0].trim();
+  return CONTENT_TYPE_LABELS[type] ?? (type.split("/").pop()?.toUpperCase() ?? type);
+}
 
 function formatUrl(url: string): string {
   try {

--- a/src/components/PwaCacheBucketList.vue
+++ b/src/components/PwaCacheBucketList.vue
@@ -35,16 +35,16 @@
           </div>
           <div class="c-pwa-cache__bucket-meta">
             {{ bucket.urls.length }} {{ bucket.urls.length === 1 ? "Eintrag" : "Einträge" }}
-            <template v-if="bucket.lastModified">
-              · neu: {{ formatRelativeTime(bucket.lastModified) }}
+            <template v-if="bucket.dateRange">
+              · neu: {{ formatRelativeTime(bucket.dateRange.lastModified) }}
             </template>
             <template
               v-if="
-                bucket.oldestEntry &&
-                bucket.oldestEntry.getTime() !== bucket.lastModified?.getTime()
+                bucket.dateRange &&
+                bucket.dateRange.oldestEntry.getTime() !== bucket.dateRange.lastModified.getTime()
               "
             >
-              · alt: {{ formatRelativeTime(bucket.oldestEntry) }}
+              · alt: {{ formatRelativeTime(bucket.dateRange.oldestEntry) }}
             </template>
           </div>
           <div v-if="bucket.typeBreakdown.length > 0" class="c-pwa-cache__bucket-types">
@@ -89,7 +89,7 @@ import {
   AccordionTrigger,
   BaseAccordion,
 } from "@components/accordion";
-import { formatBytes, getBucketDisplayName } from "@composables/useCacheStorage";
+import { CONTENT_TYPE_TO_EXT, formatBytes, getBucketDisplayName } from "@composables/useCacheStorage";
 import { VList } from "virtua/vue";
 import { defineAsyncComponent } from "vue";
 
@@ -104,24 +104,10 @@ const emit = defineEmits<{
 const ChevronDown = defineAsyncComponent(() => import("virtual:icons/lucide/chevron-down"));
 const X = defineAsyncComponent(() => import("virtual:icons/lucide/x"));
 
-const CONTENT_TYPE_LABELS: Record<string, string> = {
-  "application/javascript": "JS",
-  "application/json": "JSON",
-  "font/woff": "WOFF",
-  "font/woff2": "WOFF2",
-  "image/avif": "AVIF",
-  "image/jpeg": "JPG",
-  "image/png": "PNG",
-  "image/svg+xml": "SVG",
-  "image/webp": "WEBP",
-  "text/css": "CSS",
-  "text/html": "HTML",
-  "text/javascript": "JS",
-};
-
 function formatContentType(contentType: string): string {
   const type = contentType.split(";")[0].trim();
-  return CONTENT_TYPE_LABELS[type] ?? (type.split("/").pop()?.toUpperCase() ?? type);
+  const ext = CONTENT_TYPE_TO_EXT[type];
+  return ext ? ext.toUpperCase() : (type.split("/").pop()?.toUpperCase() ?? type);
 }
 
 function formatUrl(url: string): string {

--- a/src/components/PwaCacheOverview.vue
+++ b/src/components/PwaCacheOverview.vue
@@ -9,9 +9,12 @@
     <template v-else>
       <PwaCacheStats
         :bucket-count="buckets.length"
-        :total-size-bytes="totalSizeBytes"
         :storage-quota="storageQuota"
+        :total-entry-count="totalEntryCount"
+        :total-size-bytes="totalSizeBytes"
       />
+
+      <PwaCacheTypeBar :buckets="buckets" />
 
       <PwaCacheInfoGrid
         :sw-info="swInfo"
@@ -66,6 +69,7 @@ import PwaCacheBucketList from "@components/PwaCacheBucketList.vue";
 import PwaCacheHeader from "@components/PwaCacheHeader.vue";
 import PwaCacheInfoGrid from "@components/PwaCacheInfoGrid.vue";
 import PwaCacheStats from "@components/PwaCacheStats.vue";
+import PwaCacheTypeBar from "@components/PwaCacheTypeBar.vue";
 
 const Circle = defineAsyncComponent(() => import("virtual:icons/lucide/circle"));
 const CircleCheck = defineAsyncComponent(() => import("virtual:icons/lucide/circle-check"));
@@ -91,6 +95,8 @@ const {
 const ConfirmDialog = defineAsyncComponent(() => import("@components/ConfirmDialog.vue"));
 
 const isPwaInstalled = useStore($isPwaInstalled);
+
+const totalEntryCount = computed(() => buckets.value.reduce((sum, b) => sum + b.urls.length, 0));
 
 const storageQuotaPercent = computed(() => {
   if (!storageQuota.value || storageQuota.value.quotaBytes === 0) return 0;

--- a/src/components/PwaCacheStats.vue
+++ b/src/components/PwaCacheStats.vue
@@ -5,6 +5,10 @@
       <span class="c-pwa-cache__stat-label">{{ bucketCount === 1 ? "Cache" : "Caches" }} gecacht</span>
     </div>
     <div class="c-pwa-cache__stat">
+      <span class="c-pwa-cache__stat-value">{{ totalEntryCount }}</span>
+      <span class="c-pwa-cache__stat-label">{{ totalEntryCount === 1 ? "Eintrag" : "Einträge" }} gesamt</span>
+    </div>
+    <div class="c-pwa-cache__stat">
       <span class="c-pwa-cache__stat-value">{{ formatBytes(totalSizeBytes) }}</span>
       <span class="c-pwa-cache__stat-label">gesamt</span>
     </div>
@@ -20,7 +24,8 @@ import { formatBytes, type StorageQuota } from "@composables/useCacheStorage";
 
 defineProps<{
   bucketCount: number;
-  totalSizeBytes: number;
   storageQuota: StorageQuota | null;
+  totalEntryCount: number;
+  totalSizeBytes: number;
 }>();
 </script>

--- a/src/components/PwaCacheTypeBar.vue
+++ b/src/components/PwaCacheTypeBar.vue
@@ -72,7 +72,7 @@ const segments = computed((): Segment[] => {
       ? [...top, ["sonstige", rest.reduce((sum, [, s]) => sum + s, 0)]]
       : top;
 
-  return entries
+  const segs = entries
     .map(([type, sizeBytes], i) => ({
       color: COLORS[i % COLORS.length],
       percent: Math.round((sizeBytes / total) * 100),
@@ -80,5 +80,10 @@ const segments = computed((): Segment[] => {
       type,
     }))
     .filter((seg) => seg.percent > 0);
+
+  const diff = 100 - segs.reduce((sum, s) => sum + s.percent, 0);
+  if (segs.length > 0) segs[0].percent += diff;
+
+  return segs;
 });
 </script>

--- a/src/components/PwaCacheTypeBar.vue
+++ b/src/components/PwaCacheTypeBar.vue
@@ -1,0 +1,84 @@
+<template>
+  <div v-if="segments.length > 0" class="c-pwa-type-bar">
+    <div
+      class="c-pwa-type-bar__track"
+      role="img"
+      :aria-label="`Dateitypen nach Größe: ${segments.map((s) => `${s.type.toUpperCase()} ${s.percent}%`).join(', ')}`"
+    >
+      <div
+        v-for="seg in segments"
+        :key="seg.type"
+        class="c-pwa-type-bar__segment"
+        :style="{ backgroundColor: seg.color, width: `${seg.percent}%` }"
+        :title="`${seg.type.toUpperCase()}: ${formatBytes(seg.sizeBytes)} (${seg.percent}%)`"
+      />
+    </div>
+    <ul class="c-pwa-type-bar__legend u-list-reset">
+      <li v-for="seg in segments" :key="seg.type" class="c-pwa-type-bar__legend-item">
+        <span class="c-pwa-type-bar__legend-dot" :style="{ backgroundColor: seg.color }" />
+        <span class="c-pwa-type-bar__legend-type">{{ seg.type.toUpperCase() }}</span>
+        <span class="c-pwa-type-bar__legend-size">{{ formatBytes(seg.sizeBytes) }}</span>
+        <span class="c-pwa-type-bar__legend-pct">{{ seg.percent }}%</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { formatBytes, type CacheBucket } from "@composables/useCacheStorage";
+import { computed } from "vue";
+
+const props = defineProps<{
+  buckets: CacheBucket[];
+}>();
+
+const COLORS = [
+  "#4a9eca",
+  "#e07039",
+  "#6bbf59",
+  "#9b59b6",
+  "#e74c3c",
+  "#1abc9c",
+  "#f39c12",
+  "#95a5a6",
+];
+
+const MAX_TYPES = 7;
+
+interface Segment {
+  color: string;
+  percent: number;
+  sizeBytes: number;
+  type: string;
+}
+
+const segments = computed((): Segment[] => {
+  const map = new Map<string, number>();
+  for (const bucket of props.buckets) {
+    for (const td of bucket.typeBreakdown) {
+      map.set(td.type, (map.get(td.type) ?? 0) + td.sizeBytes);
+    }
+  }
+
+  const total = [...map.values()].reduce((sum, s) => sum + s, 0);
+  if (total === 0) return [];
+
+  const sorted = [...map.entries()].sort((a, b) => b[1] - a[1]);
+  const top = sorted.slice(0, MAX_TYPES);
+  const rest = sorted.slice(MAX_TYPES);
+
+  const entries: [string, number][] =
+    rest.length > 0
+      ? [...top, ["sonstige", rest.reduce((sum, [, s]) => sum + s, 0)]]
+      : top;
+
+  return entries
+    .map(([type, sizeBytes], i) => ({
+      color: COLORS[i % COLORS.length],
+      percent: Math.round((sizeBytes / total) * 100),
+      sizeBytes,
+      type,
+    }))
+    .filter((seg) => seg.percent > 0);
+});
+</script>

--- a/src/composable/useCacheStorage.ts
+++ b/src/composable/useCacheStorage.ts
@@ -2,12 +2,26 @@ import { useEventListener, useTimeoutFn } from "@vueuse/core";
 import { createToastNotify } from "@stores/index";
 import { computed, onMounted, ref } from "vue";
 
+export interface CacheEntry {
+  contentType: string | null;
+  date: Date | null;
+  size: number | null;
+  url: string;
+}
+
+export interface FileTypeBreakdown {
+  count: number;
+  sizeBytes: number;
+  type: string;
+}
+
 export interface CacheBucket {
-  name: string;
-  totalSizeBytes: number;
   lastModified: Date | null;
+  name: string;
   oldestEntry: Date | null;
-  urls: string[];
+  totalSizeBytes: number;
+  typeBreakdown: FileTypeBreakdown[];
+  urls: CacheEntry[];
 }
 
 export interface StorageQuota {
@@ -40,6 +54,38 @@ export function getBucketDisplayName(name: string): string {
     if (name.startsWith(prefix)) return displayName;
   }
   return name;
+}
+
+const CONTENT_TYPE_TO_EXT: Record<string, string> = {
+  "application/javascript": "js",
+  "application/json": "json",
+  "font/woff": "woff",
+  "font/woff2": "woff2",
+  "image/avif": "avif",
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/svg+xml": "svg",
+  "image/webp": "webp",
+  "text/css": "css",
+  "text/html": "html",
+  "text/javascript": "js",
+};
+
+export function getEntryType(url: string, contentType: string | null): string {
+  if (contentType) {
+    const type = contentType.split(";")[0].trim();
+    if (CONTENT_TYPE_TO_EXT[type]) return CONTENT_TYPE_TO_EXT[type];
+  }
+  try {
+    const pathname = new URL(url).pathname;
+    const lastSegment = pathname.split("/").pop() ?? "";
+    const dotIndex = lastSegment.lastIndexOf(".");
+    if (dotIndex < 1) return "other";
+    const ext = lastSegment.slice(dotIndex + 1).toLowerCase();
+    return ext.length > 0 && ext.length <= 6 ? ext : "other";
+  } catch {
+    return "other";
+  }
 }
 
 export function useCacheStorage() {
@@ -103,34 +149,50 @@ export function useCacheStorage() {
         cacheNames.map(async (name): Promise<CacheBucket> => {
           const cache = await caches.open(name);
           if (!cache)
-            return { lastModified: null, name, oldestEntry: null, totalSizeBytes: 0, urls: [] };
+            return { lastModified: null, name, oldestEntry: null, totalSizeBytes: 0, typeBreakdown: [], urls: [] };
 
           const requests = await cache.keys();
-          const urls = requests.map((req) => req.url);
 
           let totalSizeBytes = 0;
           let lastModified: Date | null = null;
           let oldestEntry: Date | null = null;
 
-          await Promise.all(
-            requests.map(async (request) => {
+          const urls = await Promise.all(
+            requests.map(async (request): Promise<CacheEntry> => {
+              const url = request.url;
               const response = await cache.match(request);
-              if (!response) return;
+              if (!response) return { contentType: null, date: null, size: null, url };
+
+              let size: number | null = null;
               try {
                 const blob = await response.clone().blob();
+                size = blob.size;
                 totalSizeBytes += blob.size;
               } catch {
                 // opaque/CORS response — skip size
               }
+
+              const contentType = response.headers.get("Content-Type");
               const dateHeader = response.headers.get("Date");
-              if (!dateHeader) return;
+              if (!dateHeader) return { contentType, date: null, size, url };
               const date = new Date(dateHeader);
               if (!lastModified || date > lastModified) lastModified = date;
               if (!oldestEntry || date < oldestEntry) oldestEntry = date;
+              return { contentType, date, size, url };
             }),
           );
 
-          return { lastModified, name, oldestEntry, totalSizeBytes, urls };
+          const typeMap = new Map<string, FileTypeBreakdown>();
+          for (const entry of urls) {
+            const type = getEntryType(entry.url, entry.contentType);
+            const existing = typeMap.get(type) ?? { count: 0, sizeBytes: 0, type };
+            existing.count++;
+            existing.sizeBytes += entry.size ?? 0;
+            typeMap.set(type, existing);
+          }
+          const typeBreakdown = [...typeMap.values()].sort((a, b) => b.sizeBytes - a.sizeBytes);
+
+          return { lastModified, name, oldestEntry, totalSizeBytes, typeBreakdown, urls };
         }),
       );
       buckets.value = settled

--- a/src/composable/useCacheStorage.ts
+++ b/src/composable/useCacheStorage.ts
@@ -9,16 +9,21 @@ export interface CacheEntry {
   url: string;
 }
 
+export type FileExtType =
+  | "avif" | "css" | "html" | "jpg" | "js" | "json"
+  | "other" | "png" | "svg" | "woff" | "woff2" | "webp"
+  | (string & {});
+
 export interface FileTypeBreakdown {
   count: number;
   sizeBytes: number;
-  type: string;
+  type: FileExtType;
 }
 
 export interface CacheBucket {
-  lastModified: Date | null;
+  /** Sorted descending by sizeBytes. */
+  dateRange: { lastModified: Date; oldestEntry: Date } | null;
   name: string;
-  oldestEntry: Date | null;
   totalSizeBytes: number;
   typeBreakdown: FileTypeBreakdown[];
   urls: CacheEntry[];
@@ -56,7 +61,7 @@ export function getBucketDisplayName(name: string): string {
   return name;
 }
 
-const CONTENT_TYPE_TO_EXT: Record<string, string> = {
+export const CONTENT_TYPE_TO_EXT: Readonly<Record<string, FileExtType>> = {
   "application/javascript": "js",
   "application/json": "json",
   "font/woff": "woff",
@@ -71,7 +76,7 @@ const CONTENT_TYPE_TO_EXT: Record<string, string> = {
   "text/javascript": "js",
 };
 
-export function getEntryType(url: string, contentType: string | null): string {
+export function getEntryType(url: string, contentType: string | null): FileExtType {
   if (contentType) {
     const type = contentType.split(";")[0].trim();
     if (CONTENT_TYPE_TO_EXT[type]) return CONTENT_TYPE_TO_EXT[type];
@@ -107,8 +112,10 @@ export function useCacheStorage() {
       if (typeof est.usage === "number" && typeof est.quota === "number") {
         storageQuota.value = { quotaBytes: est.quota, usedBytes: est.usage };
       }
-    } catch {
-      // storage.estimate() blocked by permissions policy or unavailable
+    } catch (err) {
+      if (!(err instanceof DOMException && err.name === "NotAllowedError")) {
+        console.warn("[useCacheStorage] storage.estimate() failed unexpectedly:", err);
+      }
     }
   }
 
@@ -134,7 +141,8 @@ export function useCacheStorage() {
         scriptURL: worker?.scriptURL ?? "",
         status,
       };
-    } catch {
+    } catch (err) {
+      console.warn("[useCacheStorage] serviceWorker.getRegistration() failed:", err);
       swInfo.value = { status: "not-registered" };
     }
   }
@@ -149,13 +157,9 @@ export function useCacheStorage() {
         cacheNames.map(async (name): Promise<CacheBucket> => {
           const cache = await caches.open(name);
           if (!cache)
-            return { lastModified: null, name, oldestEntry: null, totalSizeBytes: 0, typeBreakdown: [], urls: [] };
+            return { dateRange: null, name, totalSizeBytes: 0, typeBreakdown: [], urls: [] };
 
           const requests = await cache.keys();
-
-          let totalSizeBytes = 0;
-          let lastModified: Date | null = null;
-          let oldestEntry: Date | null = null;
 
           const urls = await Promise.all(
             requests.map(async (request): Promise<CacheEntry> => {
@@ -167,20 +171,35 @@ export function useCacheStorage() {
               try {
                 const blob = await response.clone().blob();
                 size = blob.size;
-                totalSizeBytes += blob.size;
-              } catch {
-                // opaque/CORS response — skip size
+              } catch (err) {
+                if (!(err instanceof TypeError)) {
+                  console.warn("[useCacheStorage] Unexpected blob() error for", url, err);
+                }
               }
 
               const contentType = response.headers.get("Content-Type");
               const dateHeader = response.headers.get("Date");
               if (!dateHeader) return { contentType, date: null, size, url };
-              const date = new Date(dateHeader);
-              if (!lastModified || date > lastModified) lastModified = date;
-              if (!oldestEntry || date < oldestEntry) oldestEntry = date;
+              const parsed = new Date(dateHeader);
+              const date = isNaN(parsed.getTime()) ? null : parsed;
               return { contentType, date, size, url };
             }),
           );
+
+          // Accumulate after Promise.all (race-free — no shared mutation inside callbacks)
+          let totalSizeBytes = 0;
+          let dateRange: { lastModified: Date; oldestEntry: Date } | null = null;
+          for (const entry of urls) {
+            if (entry.size !== null) totalSizeBytes += entry.size;
+            if (entry.date) {
+              if (dateRange) {
+                if (entry.date > dateRange.lastModified) dateRange.lastModified = entry.date;
+                if (entry.date < dateRange.oldestEntry) dateRange.oldestEntry = entry.date;
+              } else {
+                dateRange = { lastModified: entry.date, oldestEntry: entry.date };
+              }
+            }
+          }
 
           const typeMap = new Map<string, FileTypeBreakdown>();
           for (const entry of urls) {
@@ -192,13 +211,18 @@ export function useCacheStorage() {
           }
           const typeBreakdown = [...typeMap.values()].sort((a, b) => b.sizeBytes - a.sizeBytes);
 
-          return { lastModified, name, oldestEntry, totalSizeBytes, typeBreakdown, urls };
+          return { dateRange, name, totalSizeBytes, typeBreakdown, urls };
         }),
       );
+      const rejected = settled.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+      if (rejected.length > 0) {
+        rejected.forEach((r) => console.error("[useCacheStorage] Failed to load cache bucket:", r.reason));
+      }
       buckets.value = settled
         .filter((r): r is PromiseFulfilledResult<CacheBucket> => r.status === "fulfilled")
         .map((r) => r.value);
-    } catch {
+    } catch (err) {
+      console.error("[useCacheStorage] loadCaches failed:", err);
       loadError.value = "Cache-Daten konnten nicht geladen werden.";
     } finally {
       isLoading.value = false;

--- a/src/styles/components/_pwa-cache.scss
+++ b/src/styles/components/_pwa-cache.scss
@@ -197,23 +197,72 @@
     opacity: 0.6;
   }
 
-  &__urls {
+  &__bucket-types {
     display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+  }
+
+  &__type-pill {
+    font-size: 0.7rem;
+    font-family: monospace;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    background-color: color-mix(in srgb, var(--new-blue-200) 40%, transparent);
+    opacity: 0.8;
+  }
+
+  &__url-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  &__url-size {
+    font-size: 0.7rem;
+    opacity: 0.6;
+  }
+
+  &__url-type {
+    font-size: 0.65rem;
+    padding: 0.05rem 0.3rem;
+    border-radius: 2px;
+    background-color: color-mix(in srgb, var(--new-blue-200) 30%, transparent);
+    opacity: 0.8;
+  }
+
+  &__urls {
     margin-top: 0.5rem;
     padding-top: 0.5rem;
     border-top: 1px solid var(--new-blue-200);
-    overflow: hidden;
   }
 
   &__url {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.1rem 0.25rem;
     font-size: 0.75rem;
-    opacity: 0.7;
     font-family: monospace;
+    opacity: 0.7;
+  }
+
+  &__url-path {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    min-width: 0;
+  }
+
+  &__url-age {
+    white-space: nowrap;
+    flex-shrink: 0;
+    opacity: 0.7;
+    font-size: 0.7rem;
   }
 
   &__info-grid {
@@ -293,5 +342,60 @@
     height: 100%;
     background-color: vars.$success;
     transition: width 0.3s ease;
+  }
+}
+
+.c-pwa-type-bar {
+  margin-block-end: 1rem;
+
+  &__track {
+    display: flex;
+    height: 8px;
+    border-radius: 4px;
+    overflow: hidden;
+    gap: 2px;
+    background-color: color-mix(in srgb, var(--new-blue-200) 30%, transparent);
+  }
+
+  &__segment {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 0.3s ease;
+    min-width: 2px;
+  }
+
+  &__legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    margin-top: 0.5rem;
+  }
+
+  &__legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.75rem;
+  }
+
+  &__legend-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  &__legend-type {
+    font-family: monospace;
+    font-weight: 600;
+  }
+
+  &__legend-size {
+    opacity: 0.6;
+  }
+
+  &__legend-pct {
+    opacity: 0.5;
+    font-size: 0.7rem;
   }
 }

--- a/src/tests/unit/components/PwaCacheBucketList.test.ts
+++ b/src/tests/unit/components/PwaCacheBucketList.test.ts
@@ -14,9 +14,8 @@ vi.mock("virtua/vue", () => ({
 
 function makeBucket(name: string, urls: string[] = [], sizeBytes = 1024): CacheBucket {
   return {
-    lastModified: new Date("2026-01-15T12:00:00Z"),
+    dateRange: { lastModified: new Date("2026-01-15T12:00:00Z"), oldestEntry: new Date("2026-01-01T12:00:00Z") },
     name,
-    oldestEntry: new Date("2026-01-01T12:00:00Z"),
     totalSizeBytes: sizeBytes,
     typeBreakdown: [],
     urls: urls.map((url) => ({ contentType: null, date: null, size: null, url })),
@@ -88,9 +87,8 @@ describe("PwaCacheBucketList", () => {
 
   it("shows age for entry with date", async () => {
     const bucket: CacheBucket = {
-      lastModified: new Date("2026-01-15T12:00:00Z"),
+      dateRange: { lastModified: new Date("2026-01-15T12:00:00Z"), oldestEntry: new Date("2026-01-01T12:00:00Z") },
       name: "api-search-index",
-      oldestEntry: new Date("2026-01-01T12:00:00Z"),
       totalSizeBytes: 1024,
       typeBreakdown: [],
       urls: [{ contentType: null, date: new Date("2026-01-15T12:00:00Z"), size: null, url: "https://a.com/x" }],
@@ -111,5 +109,51 @@ describe("PwaCacheBucketList", () => {
     const buckets = [makeBucket("api-search-index", ["https://a.com"])];
     const wrapper = mount(PwaCacheBucketList, { props: { buckets } });
     expect(wrapper.find(".c-pwa-cache__bucket-meta").text()).toContain("neu:");
+  });
+
+  it("shows formatted size for entry with size", async () => {
+    const bucket: CacheBucket = {
+      dateRange: null,
+      name: "api-search-index",
+      totalSizeBytes: 2048,
+      typeBreakdown: [],
+      urls: [{ contentType: null, date: null, size: 2048, url: "https://a.com/x" }],
+    };
+    const wrapper = mount(PwaCacheBucketList, { props: { buckets: [bucket] } });
+    await wrapper.find(".c-pwa-cache__bucket-header").trigger("click");
+    expect(wrapper.find(".c-pwa-cache__url-size").text()).toContain("KB");
+  });
+
+  it("omits size span when entry size is null", async () => {
+    const buckets = [makeBucket("api-search-index", ["https://a.com/x"])];
+    const wrapper = mount(PwaCacheBucketList, { props: { buckets } });
+    await wrapper.find(".c-pwa-cache__bucket-header").trigger("click");
+    expect(wrapper.find(".c-pwa-cache__url-size").exists()).toBe(false);
+  });
+
+  it("shows known content type label uppercased", async () => {
+    const bucket: CacheBucket = {
+      dateRange: null,
+      name: "api-search-index",
+      totalSizeBytes: 0,
+      typeBreakdown: [],
+      urls: [{ contentType: "application/json", date: null, size: null, url: "https://a.com/x" }],
+    };
+    const wrapper = mount(PwaCacheBucketList, { props: { buckets: [bucket] } });
+    await wrapper.find(".c-pwa-cache__bucket-header").trigger("click");
+    expect(wrapper.find(".c-pwa-cache__url-type").text()).toBe("JSON");
+  });
+
+  it("shows extracted subtype for unknown content type", async () => {
+    const bucket: CacheBucket = {
+      dateRange: null,
+      name: "api-search-index",
+      totalSizeBytes: 0,
+      typeBreakdown: [],
+      urls: [{ contentType: "application/x-custom", date: null, size: null, url: "https://a.com/x" }],
+    };
+    const wrapper = mount(PwaCacheBucketList, { props: { buckets: [bucket] } });
+    await wrapper.find(".c-pwa-cache__bucket-header").trigger("click");
+    expect(wrapper.find(".c-pwa-cache__url-type").text()).toBe("X-CUSTOM");
   });
 });

--- a/src/tests/unit/components/PwaCacheBucketList.test.ts
+++ b/src/tests/unit/components/PwaCacheBucketList.test.ts
@@ -1,15 +1,25 @@
 import PwaCacheBucketList from "@components/PwaCacheBucketList.vue";
 import type { CacheBucket } from "@composables/useCacheStorage";
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("virtua/vue", () => ({
+  VList: {
+    props: ["data"],
+    setup(props: { data: unknown[] }, { slots }: { slots: any }) {
+      return () => props.data.map((item: unknown, index: number) => slots.default?.({ item, index }));
+    },
+  },
+}));
 
 function makeBucket(name: string, urls: string[] = [], sizeBytes = 1024): CacheBucket {
   return {
-    name,
-    totalSizeBytes: sizeBytes,
     lastModified: new Date("2026-01-15T12:00:00Z"),
+    name,
     oldestEntry: new Date("2026-01-01T12:00:00Z"),
-    urls,
+    totalSizeBytes: sizeBytes,
+    typeBreakdown: [],
+    urls: urls.map((url) => ({ contentType: null, date: null, size: null, url })),
   };
 }
 
@@ -73,7 +83,28 @@ describe("PwaCacheBucketList", () => {
     const buckets = [makeBucket("api-search-index", ["https://example.com/some/path"])];
     const wrapper = mount(PwaCacheBucketList, { props: { buckets } });
     await wrapper.find(".c-pwa-cache__bucket-header").trigger("click");
-    expect(wrapper.find(".c-pwa-cache__url").text()).toContain("/some/path");
+    expect(wrapper.find(".c-pwa-cache__url-path").text()).toContain("/some/path");
+  });
+
+  it("shows age for entry with date", async () => {
+    const bucket: CacheBucket = {
+      lastModified: new Date("2026-01-15T12:00:00Z"),
+      name: "api-search-index",
+      oldestEntry: new Date("2026-01-01T12:00:00Z"),
+      totalSizeBytes: 1024,
+      typeBreakdown: [],
+      urls: [{ contentType: null, date: new Date("2026-01-15T12:00:00Z"), size: null, url: "https://a.com/x" }],
+    };
+    const wrapper = mount(PwaCacheBucketList, { props: { buckets: [bucket] } });
+    await wrapper.find(".c-pwa-cache__bucket-header").trigger("click");
+    expect(wrapper.find(".c-pwa-cache__url-age").exists()).toBe(true);
+  });
+
+  it("omits age for entry without date", async () => {
+    const buckets = [makeBucket("api-search-index", ["https://a.com/x"])];
+    const wrapper = mount(PwaCacheBucketList, { props: { buckets } });
+    await wrapper.find(".c-pwa-cache__bucket-header").trigger("click");
+    expect(wrapper.find(".c-pwa-cache__url-age").exists()).toBe(false);
   });
 
   it("shows relative date in meta", () => {

--- a/src/tests/unit/components/PwaCacheStats.test.ts
+++ b/src/tests/unit/components/PwaCacheStats.test.ts
@@ -5,14 +5,14 @@ import { describe, expect, it } from "vitest";
 describe("PwaCacheStats", () => {
   it("renders bucket count", () => {
     const wrapper = mount(PwaCacheStats, {
-      props: { bucketCount: 3, totalSizeBytes: 0, storageQuota: null },
+      props: { bucketCount: 3, storageQuota: null, totalEntryCount: 0, totalSizeBytes: 0 },
     });
     expect(wrapper.find(".c-pwa-cache__stat-value").text()).toBe("3");
   });
 
   it('uses "Cache" singular for bucketCount 1', () => {
     const wrapper = mount(PwaCacheStats, {
-      props: { bucketCount: 1, totalSizeBytes: 0, storageQuota: null },
+      props: { bucketCount: 1, storageQuota: null, totalEntryCount: 0, totalSizeBytes: 0 },
     });
     expect(wrapper.text()).toContain("Cache gecacht");
     expect(wrapper.text()).not.toContain("Caches gecacht");
@@ -20,14 +20,30 @@ describe("PwaCacheStats", () => {
 
   it('uses "Caches" plural for bucketCount > 1', () => {
     const wrapper = mount(PwaCacheStats, {
-      props: { bucketCount: 2, totalSizeBytes: 0, storageQuota: null },
+      props: { bucketCount: 2, storageQuota: null, totalEntryCount: 0, totalSizeBytes: 0 },
     });
     expect(wrapper.text()).toContain("Caches gecacht");
   });
 
+  it("renders totalEntryCount", () => {
+    const wrapper = mount(PwaCacheStats, {
+      props: { bucketCount: 1, storageQuota: null, totalEntryCount: 42, totalSizeBytes: 0 },
+    });
+    expect(wrapper.text()).toContain("42");
+    expect(wrapper.text()).toContain("Einträge gesamt");
+  });
+
+  it('uses "Eintrag" singular for totalEntryCount 1', () => {
+    const wrapper = mount(PwaCacheStats, {
+      props: { bucketCount: 1, storageQuota: null, totalEntryCount: 1, totalSizeBytes: 0 },
+    });
+    expect(wrapper.text()).toContain("Eintrag gesamt");
+    expect(wrapper.text()).not.toContain("Einträge gesamt");
+  });
+
   it("formats totalSizeBytes in KB", () => {
     const wrapper = mount(PwaCacheStats, {
-      props: { bucketCount: 1, totalSizeBytes: 2048, storageQuota: null },
+      props: { bucketCount: 1, storageQuota: null, totalEntryCount: 0, totalSizeBytes: 2048 },
     });
     expect(wrapper.text()).toContain("2,0 KB");
   });
@@ -36,19 +52,20 @@ describe("PwaCacheStats", () => {
     const wrapper = mount(PwaCacheStats, {
       props: {
         bucketCount: 1,
+        storageQuota: { quotaBytes: 10_240, usedBytes: 1024 },
+        totalEntryCount: 0,
         totalSizeBytes: 0,
-        storageQuota: { usedBytes: 1024, quotaBytes: 10240 },
       },
     });
     expect(wrapper.text()).toContain("belegt");
-    expect(wrapper.findAll(".c-pwa-cache__stat")).toHaveLength(3);
+    expect(wrapper.findAll(".c-pwa-cache__stat")).toHaveLength(4);
   });
 
   it("hides quota stat when storageQuota is null", () => {
     const wrapper = mount(PwaCacheStats, {
-      props: { bucketCount: 1, totalSizeBytes: 0, storageQuota: null },
+      props: { bucketCount: 1, storageQuota: null, totalEntryCount: 0, totalSizeBytes: 0 },
     });
     expect(wrapper.text()).not.toContain("belegt");
-    expect(wrapper.findAll(".c-pwa-cache__stat")).toHaveLength(2);
+    expect(wrapper.findAll(".c-pwa-cache__stat")).toHaveLength(3);
   });
 });

--- a/src/tests/unit/components/PwaCacheTypeBar.test.ts
+++ b/src/tests/unit/components/PwaCacheTypeBar.test.ts
@@ -65,6 +65,42 @@ describe("PwaCacheTypeBar", () => {
     expect(labels.length).toBeLessThanOrEqual(8);
   });
 
+  it("does not add sonstige when types equal MAX_TYPES exactly", () => {
+    const types = ["js", "css", "avif", "webp", "woff2", "html", "json"].map(
+      (type, i) => ({ count: 1, sizeBytes: 100 - i, type }),
+    );
+    const wrapper = mount(PwaCacheTypeBar, { props: { buckets: [makeBucket(types)] } });
+    const labels = wrapper.findAll(".c-pwa-type-bar__legend-type").map((el) => el.text());
+    expect(labels).not.toContain("SONSTIGE");
+    expect(labels).toHaveLength(7);
+  });
+
+  it("omits segments that round to 0%", () => {
+    const bucket = makeBucket([
+      { count: 1, sizeBytes: 100_000, type: "js" },
+      { count: 1, sizeBytes: 1, type: "other" },
+    ]);
+    const wrapper = mount(PwaCacheTypeBar, { props: { buckets: [bucket] } });
+    const labels = wrapper.findAll(".c-pwa-type-bar__legend-type").map((el) => el.text());
+    expect(labels).not.toContain("OTHER");
+  });
+
+  it("percents sum to 100 after rounding adjustment", () => {
+    const bucket = makeBucket([
+      { count: 1, sizeBytes: 100, type: "js" },
+      { count: 1, sizeBytes: 100, type: "css" },
+      { count: 1, sizeBytes: 100, type: "html" },
+    ]);
+    const wrapper = mount(PwaCacheTypeBar, { props: { buckets: [bucket] } });
+    const segments = wrapper.findAll(".c-pwa-type-bar__segment");
+    const total = segments.reduce((sum, s) => {
+      const w = s.attributes("style") ?? "";
+      const match = w.match(/width:\s*([\d.]+)%/);
+      return sum + (match ? parseFloat(match[1]) : 0);
+    }, 0);
+    expect(total).toBe(100);
+  });
+
   it("assigns unique colors to each segment", () => {
     const bucket = makeBucket([
       { count: 1, sizeBytes: 100, type: "js" },

--- a/src/tests/unit/components/PwaCacheTypeBar.test.ts
+++ b/src/tests/unit/components/PwaCacheTypeBar.test.ts
@@ -1,0 +1,78 @@
+import PwaCacheTypeBar from "@components/PwaCacheTypeBar.vue";
+import type { CacheBucket } from "@composables/useCacheStorage";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+function makeBucket(typeBreakdown: CacheBucket["typeBreakdown"]): CacheBucket {
+  return {
+    lastModified: null,
+    name: "test",
+    oldestEntry: null,
+    totalSizeBytes: 0,
+    typeBreakdown,
+    urls: [],
+  };
+}
+
+describe("PwaCacheTypeBar", () => {
+  it("renders nothing when no buckets", () => {
+    const wrapper = mount(PwaCacheTypeBar, { props: { buckets: [] } });
+    expect(wrapper.find(".c-pwa-type-bar").exists()).toBe(false);
+  });
+
+  it("renders nothing when all typeBreakdowns are empty", () => {
+    const wrapper = mount(PwaCacheTypeBar, {
+      props: { buckets: [makeBucket([])] },
+    });
+    expect(wrapper.find(".c-pwa-type-bar").exists()).toBe(false);
+  });
+
+  it("renders track and legend when data present", () => {
+    const bucket = makeBucket([
+      { count: 5, sizeBytes: 500, type: "js" },
+      { count: 3, sizeBytes: 300, type: "css" },
+    ]);
+    const wrapper = mount(PwaCacheTypeBar, { props: { buckets: [bucket] } });
+    expect(wrapper.find(".c-pwa-type-bar__track").exists()).toBe(true);
+    expect(wrapper.findAll(".c-pwa-type-bar__segment")).toHaveLength(2);
+    expect(wrapper.findAll(".c-pwa-type-bar__legend-item")).toHaveLength(2);
+  });
+
+  it("aggregates types across multiple buckets", () => {
+    const buckets = [
+      makeBucket([{ count: 1, sizeBytes: 200, type: "js" }]),
+      makeBucket([{ count: 1, sizeBytes: 300, type: "js" }]),
+    ];
+    const wrapper = mount(PwaCacheTypeBar, { props: { buckets } });
+    expect(wrapper.findAll(".c-pwa-type-bar__segment")).toHaveLength(1);
+    expect(wrapper.find(".c-pwa-type-bar__legend-item").text()).toContain("JS");
+  });
+
+  it("shows type labels uppercased", () => {
+    const bucket = makeBucket([{ count: 1, sizeBytes: 100, type: "avif" }]);
+    const wrapper = mount(PwaCacheTypeBar, { props: { buckets: [bucket] } });
+    expect(wrapper.find(".c-pwa-type-bar__legend-type").text()).toBe("AVIF");
+  });
+
+  it("groups types beyond MAX into sonstige", () => {
+    const types = ["js", "css", "avif", "webp", "woff2", "html", "json", "png"].map(
+      (type, i) => ({ count: 1, sizeBytes: 100 - i * 10, type }),
+    );
+    const bucket = makeBucket(types);
+    const wrapper = mount(PwaCacheTypeBar, { props: { buckets: [bucket] } });
+    const labels = wrapper.findAll(".c-pwa-type-bar__legend-type").map((el) => el.text());
+    expect(labels).toContain("SONSTIGE");
+    expect(labels.length).toBeLessThanOrEqual(8);
+  });
+
+  it("assigns unique colors to each segment", () => {
+    const bucket = makeBucket([
+      { count: 1, sizeBytes: 100, type: "js" },
+      { count: 1, sizeBytes: 80, type: "css" },
+    ]);
+    const wrapper = mount(PwaCacheTypeBar, { props: { buckets: [bucket] } });
+    const segments = wrapper.findAll(".c-pwa-type-bar__segment");
+    const colors = segments.map((s) => s.attributes("style"));
+    expect(colors[0]).not.toBe(colors[1]);
+  });
+});

--- a/src/tests/unit/composable/useCacheStorage.test.ts
+++ b/src/tests/unit/composable/useCacheStorage.test.ts
@@ -1,4 +1,4 @@
-import { formatBytes, getBucketDisplayName } from "@composables/useCacheStorage";
+import { formatBytes, getBucketDisplayName, getEntryType } from "@composables/useCacheStorage";
 import { useCacheStorage } from "@composables/useCacheStorage";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createApp, nextTick } from "vue";
@@ -21,18 +21,18 @@ function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
 
 // Helper: builds a mock CacheStorage
 function makeMockCacheStorage(
-  data: Record<string, Array<{ url: string; dateStr?: string; size?: number }>>,
+  data: Record<string, Array<{ url: string; dateStr?: string; size?: number; contentType?: string }>>,
 ) {
   const cacheInstances = Object.fromEntries(
     Object.entries(data).map(([name, entries]) => {
       const requests = entries.map((e) => new Request(e.url));
       const responseMap = new Map(
-        entries.map((e) => [
-          e.url,
-          new Response(new Uint8Array(e.size ?? 100), {
-            headers: e.dateStr ? { Date: e.dateStr } : {},
-          }),
-        ]),
+        entries.map((e) => {
+          const headers: Record<string, string> = {};
+          if (e.dateStr) headers.Date = e.dateStr;
+          if (e.contentType) headers["Content-Type"] = e.contentType;
+          return [e.url, new Response(new Uint8Array(e.size ?? 100), { headers })];
+        }),
       );
       return [
         name,
@@ -105,6 +105,40 @@ describe("getBucketDisplayName", () => {
   });
 });
 
+describe("getEntryType", () => {
+  it("prefers Content-Type over URL extension", () => {
+    expect(getEntryType("https://example.com/data.json", "application/javascript")).toBe("js");
+  });
+
+  it("strips charset suffix from Content-Type", () => {
+    expect(getEntryType("https://example.com/page", "text/html; charset=utf-8")).toBe("html");
+  });
+
+  it("falls through to URL extension when contentType is null", () => {
+    expect(getEntryType("https://example.com/app.js", null)).toBe("js");
+  });
+
+  it("returns other when URL has no dot", () => {
+    expect(getEntryType("https://example.com/pwa", null)).toBe("other");
+  });
+
+  it("returns other for dot at position 0 (.hidden files)", () => {
+    expect(getEntryType("https://example.com/.hidden", null)).toBe("other");
+  });
+
+  it("returns other for extension longer than 6 chars", () => {
+    expect(getEntryType("https://example.com/file.toolong", null)).toBe("other");
+  });
+
+  it("returns other for unknown Content-Type with no URL extension", () => {
+    expect(getEntryType("https://example.com/api/data", "application/x-custom-type")).toBe("other");
+  });
+
+  it("returns other for malformed URL", () => {
+    expect(getEntryType("not a url at all", null)).toBe("other");
+  });
+});
+
 describe("useCacheStorage — loadCaches", () => {
   let mockCacheStorage: ReturnType<typeof makeMockCacheStorage>;
 
@@ -152,21 +186,20 @@ describe("useCacheStorage — loadCaches", () => {
     unmount();
   });
 
-  it("reads lastModified from Date header", async () => {
+  it("reads lastModified from Date header via dateRange", async () => {
     const { result, unmount } = withSetup(() => useCacheStorage());
     await result.loadCaches();
     const idx = result.buckets.value.find((b) => b.name === "api-search-index")!;
-    expect(idx.lastModified).toBeInstanceOf(Date);
-    expect(idx.lastModified?.toISOString()).toBe("2026-01-01T10:00:00.000Z");
+    expect(idx.dateRange?.lastModified).toBeInstanceOf(Date);
+    expect(idx.dateRange?.lastModified.toISOString()).toBe("2026-01-01T10:00:00.000Z");
     unmount();
   });
 
-  it("sets lastModified to null when no Date header", async () => {
+  it("sets dateRange to null when no Date header", async () => {
     const { result, unmount } = withSetup(() => useCacheStorage());
     await result.loadCaches();
     const wotd = result.buckets.value.find((b) => b.name === "api-word-of-the-day")!;
-    expect(wotd.lastModified).toBeNull();
-    expect(wotd.oldestEntry).toBeNull();
+    expect(wotd.dateRange).toBeNull();
     unmount();
   });
 
@@ -183,8 +216,8 @@ describe("useCacheStorage — loadCaches", () => {
     const { result, unmount } = withSetup(() => useCacheStorage());
     await result.loadCaches();
     const bucket = result.buckets.value.find((b) => b.name === "api-search-index")!;
-    expect(bucket.lastModified?.toISOString()).toBe("2026-01-01T12:00:00.000Z");
-    expect(bucket.oldestEntry?.toISOString()).toBe("2026-01-01T08:00:00.000Z");
+    expect(bucket.dateRange?.lastModified.toISOString()).toBe("2026-01-01T12:00:00.000Z");
+    expect(bucket.dateRange?.oldestEntry.toISOString()).toBe("2026-01-01T08:00:00.000Z");
     unmount();
   });
 
@@ -209,6 +242,44 @@ describe("useCacheStorage — loadCaches", () => {
     const { result, unmount } = withSetup(() => useCacheStorage());
     await result.loadCaches();
     expect(result.buckets.value).toEqual([]);
+    unmount();
+  });
+
+  it("populates typeBreakdown sorted descending by sizeBytes", async () => {
+    vi.stubGlobal(
+      "caches",
+      makeMockCacheStorage({
+        "api-search-index": [
+          { url: "https://example.com/a.js", size: 500, contentType: "application/javascript" },
+          { url: "https://example.com/b.css", size: 200, contentType: "text/css" },
+        ],
+      }),
+    );
+    const { result, unmount } = withSetup(() => useCacheStorage());
+    await result.loadCaches();
+    const bucket = result.buckets.value.find((b) => b.name === "api-search-index")!;
+    expect(bucket.typeBreakdown[0].type).toBe("js");
+    expect(bucket.typeBreakdown[0].sizeBytes).toBe(500);
+    expect(bucket.typeBreakdown[1].type).toBe("css");
+    unmount();
+  });
+
+  it("aggregates count and sizeBytes for same type", async () => {
+    vi.stubGlobal(
+      "caches",
+      makeMockCacheStorage({
+        "api-search-index": [
+          { url: "https://example.com/a.json", size: 300, contentType: "application/json" },
+          { url: "https://example.com/b.json", size: 200, contentType: "application/json" },
+        ],
+      }),
+    );
+    const { result, unmount } = withSetup(() => useCacheStorage());
+    await result.loadCaches();
+    const bucket = result.buckets.value.find((b) => b.name === "api-search-index")!;
+    expect(bucket.typeBreakdown).toHaveLength(1);
+    expect(bucket.typeBreakdown[0].count).toBe(2);
+    expect(bucket.typeBreakdown[0].sizeBytes).toBe(500);
     unmount();
   });
 });


### PR DESCRIPTION
- CacheEntry now carries size, contentType, date per cached response
- CacheBucket gains typeBreakdown[] (aggregated by Content-Type with URL-extension fallback)
- PwaCacheBucketList shows size/type/age per VList row; bucket header shows type pills (label + count) via virtua VList for large lists
- PwaCacheTypeBar: new segmented bar (GitHub-style) aggregating types across all buckets with color-coded legend
- PwaCacheStats gains totalEntryCount stat tile