### PR TITLE
perf(search): defer Orama init after first paint to fix LCP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,11 @@
+# Content-hashed assets — safe to cache forever (URL changes on every build)
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Build-time generated search indexes — cache for 1 day
+# Cloudflare Pages purges all caches on every deploy
+/api/search/index.json
+  Cache-Control: public, max-age=86400, stale-while-revalidate=3600
+
+/api/search/meta.json
+  Cache-Control: public, max-age=86400, stale-while-revalidate=3600

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -92,6 +92,7 @@ const navMenu2 = [
         class='c-footer__farewell-image'
         formats={['avif', 'webp']}
         layout='constrained'
+        sizes="(min-width: 1024px) 40vw, 50vw"
         src={BearWalking}
       />
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -104,6 +104,7 @@ const facts = [
         formats={['avif', 'webp']}
         layout='constrained'
         priority={true}
+        sizes="(min-width: 900px) 900px, (min-width: 768px) 50vw, (min-width: 568px) 85vw, 64vw"
         src={BrownBearRoar}
       />
     </div>

--- a/src/stores/wordList.ts
+++ b/src/stores/wordList.ts
@@ -296,6 +296,8 @@ const wordSchema = {
 type WordDocument = TypedDocument<Orama<typeof wordSchema>>;
 
 let db: null | Orama<typeof wordSchema> = null;
+let dbInitializing = false;
+const dbInitWaiters: Array<() => void> = [];
 
 type SortByType =
   | ((a: [number, number, WordDocument], b: [number, number, WordDocument]) => number)
@@ -364,7 +366,14 @@ function getSortBy(wordSearch: WordList): SortByType {
 }
 
 async function initOrama(words: OramaSearchIndex[]) {
-  db = create({
+  if (dbInitializing) {
+    await new Promise<void>((r) => dbInitWaiters.push(r));
+    return;
+  }
+
+  dbInitializing = true;
+
+  const localDb = create({
     components: {
       tokenizer: {
         language,
@@ -390,7 +399,12 @@ async function initOrama(words: OramaSearchIndex[]) {
     schema: wordSchema,
   });
 
-  await insertMultiple(db, words);
+  await insertMultiple(localDb, words);
+
+  db = localDb;
+  dbInitializing = false;
+  for (const r of dbInitWaiters) r();
+  dbInitWaiters.length = 0;
 }
 
 let searchIndexCache: null | OramaSearchIndex[] = null;
@@ -409,6 +423,8 @@ export const $oramaSearchResults = computedAsync([$wordSearch], async (wordSearc
     const resultLimit = oramaSearchIndex.length;
 
     if (!db) {
+      // Defer until after first paint so the LCP element can render first
+      await new Promise<void>((r) => requestAnimationFrame(() => setTimeout(r, 0)));
       await initOrama(oramaSearchIndex);
     }
 


### PR DESCRIPTION
Orama's insertMultiple was blocking the main thread during initial page
load, causing a 3040ms element render delay on the LCP image (brown bear).

Fix: defer Orama initialization past the first animation frame so the
browser can paint the LCP element before the CPU-intensive index build
starts. A race-condition lock (dbInitializing + dbInitWaiters) prevents
concurrent init calls during the defer window. db is only assigned once
insertMultiple completes, so searches never run against a partial index.

Also add public/_headers to set long-lived cache headers for content-
hashed /_astro/* assets (immutable) and build-time search index JSON
(1-day TTL). The search index previously had max-age=0, causing a full
re-download on every page visit.