### PR TITLE
fix: include Firefox ESR in supported browser detection

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,6 @@
 last 2 Chrome versions
 last 2 Firefox versions
+Firefox ESR
 last 2 Edge versions
 last 2 Safari versions
 last 2 iOS versions

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,9 +1,1 @@
-last 2 Chrome versions
-last 2 Firefox versions
-Firefox ESR
-last 2 Edge versions
-last 2 Safari versions
-last 2 iOS versions
-last 2 Android versions
-not dead
-not IE 11
+defaults


### PR DESCRIPTION
"last 2 Firefox versions" only matches the two newest rapid-release
versions, which are far ahead of the ESR track. Firefox ESR users
(e.g. Debian/Ubuntu default installs) were being flagged as
unsupported by checkBrowserSupport() even on a current ESR build.