### PR TITLE
fix(word): remove unwanted space before article comma in word hero title

### DIFF
--- a/src/components/word/WordHero.astro
+++ b/src/components/word/WordHero.astro
@@ -28,8 +28,9 @@ const themen = word.berlinerischThemen?.nodes ?? [];
 >
   <div class='c-word-hero__left'>
     <h1 class='c-word-hero__title'>
-      <dfn>{wordProps?.berlinerisch}</dfn>
-      {wordProps?.article && <span class='c-word-hero__word-article'>, {wordProps.article}</span>}
+      <dfn>{wordProps?.berlinerisch}</dfn>{wordProps?.article && (
+        <span class='c-word-hero__word-article'>, {wordProps.article}</span>
+      )}
     </h1>
     <div class='c-word-hero__badges'>
       {


### PR DESCRIPTION
Whitespace between </dfn> and the article span was rendered as a real
space by compressHTML: true, producing "Wort ," instead of "Wort,".